### PR TITLE
Change stretch to buster in repo configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN set -ex; \
 		ca-certificates \
 		curl \
 		gnupg; \
-	echo deb http://packages.prosody.im/debian stretch main \
+	echo deb http://packages.prosody.im/debian buster main \
 	| tee -a /etc/apt/sources.list; \
 	curl -fsSL https://prosody.im/files/prosody-debian-packages.key \
 	| apt-key add -; \


### PR DESCRIPTION
Otherwise you get the following error:
`E: Failed to fetch http://packages.prosody.im/debian/dists/stretch/InRelease  410  Gone [IP: 46.43.15.35 80]`